### PR TITLE
Fix samples

### DIFF
--- a/src/NModbus.Examples.ModbusClient/ModbusIpClientSampleTransportFactory.cs
+++ b/src/NModbus.Examples.ModbusClient/ModbusIpClientSampleTransportFactory.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.Extensions.Logging;
+using NModbus.Interfaces;
+using NModbus.Transport.IP;
+using NModbus.Transport.IP.ConnectionStrategies;
+using System.Net;
+using System.Net.Security;
+
+namespace NModbus.Examples.ModbusClient;
+
+internal class ModbusIpClientSampleTransportFactory
+{
+    private readonly ILoggerFactory _loggerFactory;
+
+    public ModbusIpClientSampleTransportFactory(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+    }
+
+    public IModbusClientTransport CreateTcpInsecureClient(IPAddress serverAddress)
+    {
+        IStreamFactory streamFactory = new TcpStreamFactory(new(serverAddress, ModbusIPPorts.Insecure));
+
+        return BuildClientTransport(streamFactory);
+    }
+
+    public IModbusClientTransport CreateUpdClient(IPAddress serverAddress)
+    {
+        IStreamFactory streamFactory = new UdpStreamFactory(new(serverAddress, ModbusIPPorts.Insecure), s =>
+        {
+            s.Client.ReceiveTimeout = 5000;
+            s.Client.SendTimeout = 5000;
+        });
+
+        return BuildClientTransport(streamFactory);
+    }
+
+    public async Task<IModbusClientTransport> CreateTcpSecureClient(string serverDnsName, RemoteCertificateValidationCallback certificateValidationCallback)
+    {
+        var options = new SslClientAuthenticationOptions
+        {
+            TargetHost = serverDnsName,
+            EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13,
+            RemoteCertificateValidationCallback = certificateValidationCallback
+        };
+
+        IPHostEntry serverAddresses = await Dns.GetHostEntryAsync(serverDnsName);
+
+        IStreamFactory streamFactory = new TcpStreamFactory(new IPEndPoint(serverAddresses.AddressList[0], ModbusIPPorts.Secure), null, options);
+
+        return BuildClientTransport(streamFactory);
+    }
+
+    private IModbusClientTransport BuildClientTransport(IStreamFactory streamFactory)
+    {
+        IConnectionStrategy strategy = new SingletonStreamConnectionStrategy(streamFactory, _loggerFactory);
+
+        return new ModbusIPClientTransport(strategy, _loggerFactory);
+    }
+}

--- a/src/NModbus.Examples.ModbusClient/Program.cs
+++ b/src/NModbus.Examples.ModbusClient/Program.cs
@@ -1,12 +1,9 @@
 ﻿using Microsoft.Extensions.Logging;
 using NModbus;
-using NModbus.Transport.IP;
-using NModbus.Transport.IP.ConnectionStrategies;
+using NModbus.Examples.ModbusClient;
 using System.Net;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 
-var loggerFactory = LoggerFactory.Create(builder =>
+ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
 {
     builder
         .SetMinimumLevel(LogLevel.Debug)
@@ -20,45 +17,23 @@ const byte unitIdentifier = 1;
 
 // options = null
 
-#if FALSE
+var sampleFactory = new ModbusIpClientSampleTransportFactory(loggerFactory);
 
-var streamFactory = new TcpClientFactory(IPAddress.Loopback, ModbusTcpPorts.Insecure);
+string sample = "ip";
 
-var strategy = new SingletonStreamConnectionStrategy(streamFactory, loggerFactory);
-
-#elif TRUE
-
-var streamFactory = new UdpStreamFactory(new IPEndPoint(IPAddress.Loopback, ModbusIPPorts.Insecure), 
-    s => {
-        s.Client.ReceiveTimeout = 5000;
-        s.Client.SendTimeout = 5000;
-     });
-
-var strategy = new SingletonStreamConnectionStrategy(streamFactory, loggerFactory);
-
-#else
-
-var options = new SslClientAuthenticationOptions
+await using var transport = sample switch
 {
-    TargetHost = "127.0.0.1",
-    EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13,
-    RemoteCertificateValidationCallback = RemoteCertificateValidationCallback
+    "insecure" => sampleFactory.CreateTcpInsecureClient(IPAddress.Loopback),
+    "secure" => await sampleFactory.CreateTcpSecureClient("localhost", (snd, cert, chain, errors) => true),
+    "udp" => sampleFactory.CreateUpdClient(IPAddress.Loopback),
+    _ => throw new NotSupportedException("Only 'insecure', 'secure' or 'udp' is supported as option")
 };
-
-var streamFactory = new TcpStreamFactory(new IPEndPoint(IPAddress.Loopback, ModbusIPPorts.Secure), null, options);
-
-var strategy = new SingletonStreamConnectionStrategy(streamFactory, loggerFactory);
-
-#endif
-
-await using var transport = new ModbusIPClientTransport(strategy, loggerFactory);
 
 var modbusClient = new ModbusClient(transport, loggerFactory);
 
 logger.LogInformation("Writing a single register...");
 
 await modbusClient.WriteSingleRegisterAsync(unitIdentifier, 0, 44);
-
 {
     var holdingRegisters = await modbusClient.ReadHoldingRegistersAsync(unitIdentifier, 0, 5);
 
@@ -79,7 +54,3 @@ Console.WriteLine("Press any key to exit...");
 Console.ReadKey();
 
 
-static bool RemoteCertificateValidationCallback(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
-{
-    return true;
-}

--- a/src/NModbus.Examples.ModbusClient/Program.cs
+++ b/src/NModbus.Examples.ModbusClient/Program.cs
@@ -15,17 +15,21 @@ var logger = loggerFactory.CreateLogger<Program>();
 //The unit number of the modbus server
 const byte unitIdentifier = 1;
 
-// options = null
-
 var sampleFactory = new ModbusIpClientSampleTransportFactory(loggerFactory);
 
-string sample = "ip";
+string sample = "insecure";
 
 await using var transport = sample switch
 {
+    // create a "standard" modbus tcp client
     "insecure" => sampleFactory.CreateTcpInsecureClient(IPAddress.Loopback),
+
+    // create a modbus secure client, accepting all certificates
     "secure" => await sampleFactory.CreateTcpSecureClient("localhost", (snd, cert, chain, errors) => true),
+
+    // create a "standard" modbus upd client
     "udp" => sampleFactory.CreateUpdClient(IPAddress.Loopback),
+
     _ => throw new NotSupportedException("Only 'insecure', 'secure' or 'udp' is supported as option")
 };
 


### PR DESCRIPTION
I tried the Modbus Client TCP sample and found that the naming had changed after you've commented the sample.

I tried to clean it up a bit and allow all code to be active and not removed by pre processor conditions.